### PR TITLE
reset & validate fields between form switches, fix disappearing token index field

### DIFF
--- a/ui/src/AppWrapper.tsx
+++ b/ui/src/AppWrapper.tsx
@@ -1,7 +1,10 @@
 import { styled } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { Header } from './components/Header';
+import { EventContext } from './contexts/EventContext';
+import { IEvent } from './interfaces/api';
+import { IEventHistoryItem } from './interfaces/events';
 
 const Main = styled('main')({
   display: 'flex',
@@ -14,8 +17,70 @@ const RootDiv = styled('div')({
   display: 'flex',
 });
 
+let dumbAwaitedEventID: string | undefined = undefined;
+export const setDumbAwaitedEventId = (eventId: string | undefined) => {
+  dumbAwaitedEventID = eventId;
+};
 export const AppWrapper: React.FC = () => {
   const { pathname } = useLocation();
+  const [logHistory, setLogHistory] = useState<Map<string, IEventHistoryItem>>(
+    new Map()
+  );
+  const [justSubmitted, setJustSubmitted] = useState<boolean>(false);
+
+  const isFinalEvent = (t: string) => {
+    return (
+      t.endsWith('confirmed') || t.endsWith('rejected') || t.endsWith('failed')
+    );
+  };
+
+  const isFailed = (t: string) => {
+    return t.endsWith('rejected') || t.endsWith('failed');
+  };
+
+  const addLogToHistory = (event: IEvent) => {
+    setLogHistory((logHistory) => {
+      // This is bad practice, and should be optimized in the future
+      const deepCopyMap: Map<string, IEventHistoryItem> = new Map(
+        JSON.parse(JSON.stringify(Array.from(logHistory)))
+      );
+      const txMap = deepCopyMap.get(event.tx);
+
+      if (txMap !== undefined) {
+        // TODO: Need better logic
+        const isComplete = !!(
+          event.reference === dumbAwaitedEventID || event.correlator
+        );
+        if (isComplete) {
+          dumbAwaitedEventID = undefined;
+          setJustSubmitted(false);
+        }
+        return new Map(
+          deepCopyMap.set(event.tx, {
+            events: [event, ...txMap.events],
+            created: event.created,
+            isComplete: isFinalEvent(event.type),
+            isFailed: isFailed(event.type),
+          })
+        );
+      } else {
+        return new Map(
+          deepCopyMap.set(event.tx, {
+            events: [event],
+            created: event.created,
+            isComplete: isFinalEvent(event.type),
+            isFailed: isFailed(event.type),
+          })
+        );
+      }
+    });
+  };
+
+  const addAwaitedEventID = (apiRes: any) => {
+    if (apiRes?.id && apiRes?.id) {
+      dumbAwaitedEventID = apiRes.id;
+    }
+  };
 
   if (pathname === '/') {
     return <Navigate to="/home" replace={true} />;
@@ -24,8 +89,19 @@ export const AppWrapper: React.FC = () => {
   return (
     <RootDiv>
       <Main>
-        <Header></Header>
-        <Outlet />
+        <EventContext.Provider
+          value={{
+            logHistory,
+            addLogToHistory,
+            addAwaitedEventID,
+            justSubmitted,
+            setJustSubmitted,
+            dumbAwaitedEventID,
+          }}
+        >
+          <Header></Header>
+          <Outlet />
+        </EventContext.Provider>
       </Main>
     </RootDiv>
   );

--- a/ui/src/AppWrapper.tsx
+++ b/ui/src/AppWrapper.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { Header } from './components/Header';
 import { EventContext } from './contexts/EventContext';
@@ -28,6 +28,10 @@ export const AppWrapper: React.FC = () => {
   );
   const [justSubmitted, setJustSubmitted] = useState<boolean>(false);
 
+  useEffect(() => {
+    setJustSubmitted(false);
+  }, [dumbAwaitedEventID]);
+
   const isFinalEvent = (t: string) => {
     return (
       t.endsWith('confirmed') || t.endsWith('rejected') || t.endsWith('failed')
@@ -51,7 +55,7 @@ export const AppWrapper: React.FC = () => {
         const isComplete = !!(
           event.reference === dumbAwaitedEventID || event.correlator
         );
-        if (isComplete) {
+        if (isComplete || isFailed(event.type)) {
           dumbAwaitedEventID = undefined;
           setJustSubmitted(false);
         }

--- a/ui/src/components/Buttons/RunButton.tsx
+++ b/ui/src/components/Buttons/RunButton.tsx
@@ -33,16 +33,21 @@ export const RunButton: React.FC<Props> = ({ endpoint, payload, disabled }) => {
     setJustSubmitted,
   } = useContext(EventContext);
 
+  useEffect(() => {
+    setJustSubmitted(false);
+    setDumbAwaitedEventId(undefined);
+  }, [activeForm]);
+
+  useEffect(() => {
+    setJustSubmitted(false);
+  }, [dumbAwaitedEventID]);
+
   const handleCloseSnackbar = (_: any, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
-
     setShowSnackbar(false);
   };
-  useEffect(() => {
-    setJustSubmitted(false);
-  }, [dumbAwaitedEventID]);
 
   const handlePost = () => {
     setApiStatus(undefined);

--- a/ui/src/components/Buttons/RunButton.tsx
+++ b/ui/src/components/Buttons/RunButton.tsx
@@ -9,9 +9,11 @@ import {
 } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { setDumbAwaitedEventId } from '../../AppWrapper';
 import { ApplicationContext } from '../../contexts/ApplicationContext';
 import { EventContext } from '../../contexts/EventContext';
 import { DEFAULT_BORDER_RADIUS } from '../../theme';
+import { isSuccessfulResponse } from '../../utils/strings';
 
 interface Props {
   endpoint: string;
@@ -24,9 +26,12 @@ export const RunButton: React.FC<Props> = ({ endpoint, payload, disabled }) => {
   const [showSnackbar, setShowSnackbar] = useState(false);
   const { activeForm, setApiStatus, setApiResponse, payloadMissingFields } =
     useContext(ApplicationContext);
-  const { dumbAwaitedEventID, addAwaitedEventID } = useContext(EventContext);
-  // TODO: Remove soon
-  const [justSubmitted, setJustSubmitted] = useState<boolean>(false);
+  const {
+    addAwaitedEventID,
+    dumbAwaitedEventID,
+    justSubmitted,
+    setJustSubmitted,
+  } = useContext(EventContext);
 
   const handleCloseSnackbar = (_: any, reason?: string) => {
     if (reason === 'clickaway') {
@@ -35,13 +40,13 @@ export const RunButton: React.FC<Props> = ({ endpoint, payload, disabled }) => {
 
     setShowSnackbar(false);
   };
-
-  // TODO: Remove soon
   useEffect(() => {
     setJustSubmitted(false);
   }, [dumbAwaitedEventID]);
 
   const handlePost = () => {
+    setApiStatus(undefined);
+    setApiResponse({});
     const blobUpload = activeForm.includes('blob');
     managePayload();
     const reqDetails: any = {
@@ -68,6 +73,9 @@ export const RunButton: React.FC<Props> = ({ endpoint, payload, disabled }) => {
         if (response.status === 202) {
           setJustSubmitted(true);
           addAwaitedEventID(data);
+        } else if (!isSuccessfulResponse(response.status)) {
+          setJustSubmitted(false);
+          setDumbAwaitedEventId(undefined);
         }
       })
       .catch((err) => {

--- a/ui/src/components/Forms/BroadcastForm.tsx
+++ b/ui/src/components/Forms/BroadcastForm.tsx
@@ -10,7 +10,7 @@ import {
 } from '../Buttons/MessageTypeGroup';
 
 export const BroadcastForm: React.FC = () => {
-  const { jsonPayload, setJsonPayload, activeForm } =
+  const { jsonPayload, setJsonPayload, activeForm, setPayloadMissingFields } =
     useContext(ApplicationContext);
 
   const { t } = useTranslation();
@@ -23,6 +23,7 @@ export const BroadcastForm: React.FC = () => {
   useEffect(() => {
     if (!activeForm.includes('broadcast')) return;
     const { jsonValue: jsonCurValue } = jsonPayload as any;
+    setPayloadMissingFields(!message);
     setJsonPayload({
       topic: topics,
       tag,

--- a/ui/src/components/Forms/BurnForm.tsx
+++ b/ui/src/components/Forms/BurnForm.tsx
@@ -28,13 +28,13 @@ export const BurnForm: React.FC = () => {
   const [tokenPools, setTokenPools] = useState<ITokenPool[]>([]);
   const [pool, setPool] = useState<ITokenPool>();
   const [amount, setAmount] = useState<number>(0);
-  const [tokenIndex, setTokenIndex] = useState<number | null>();
+  const [tokenIndex, setTokenIndex] = useState<string | null>('');
   const [refresh, setRefresh] = useState<number>(0);
   const [tokenBalance, setTokenBalance] = useState<number>(0);
 
   useEffect(() => {
     if (activeForm !== TUTORIALS.BURN) return;
-    setPayloadMissingFields(!amount);
+    setPayloadMissingFields(!amount || !pool || (!isFungible() && !tokenIndex));
     setJsonPayload({
       pool: pool?.name,
       amount,
@@ -79,7 +79,6 @@ export const BurnForm: React.FC = () => {
   }, [pool, refresh]);
 
   useEffect(() => {
-    setTokenIndex(isFungible() ? null : 1);
     if (!isFungible()) {
       setAmount(1);
     }
@@ -93,10 +92,7 @@ export const BurnForm: React.FC = () => {
   const handleTokenIndexChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    const index = parseInt(event.target.value);
-    if (index && index > 0) {
-      setTokenIndex(index);
-    }
+    setTokenIndex(event.target.value);
   };
 
   const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -159,36 +155,27 @@ export const BurnForm: React.FC = () => {
             ></RefreshIcon>
           </Button>
         </Grid>
-        <Grid container item justifyContent="space-between" spacing={1}>
-          {/* From Address */}
-          {/* Amount */}
-          <Grid item xs={6}>
-            <FormControl fullWidth required>
-              <TextField
-                fullWidth
-                disabled={!isFungible()}
-                value={amount}
-                type="number"
-                label="Amount"
-                placeholder="ex. 10"
-                onChange={handleAmountChange}
-              />
-            </FormControl>
-          </Grid>
+        <Grid item xs={4}>
+          <FormControl fullWidth required>
+            <TextField
+              fullWidth
+              value={amount}
+              disabled={!isFungible()}
+              type="number"
+              label={t('amount')}
+              placeholder="ex. 10"
+              onChange={handleAmountChange}
+            />
+          </FormControl>
         </Grid>
-        {tokenIndex && tokenIndex > -1 ? (
+        {!isFungible() ? (
           <Grid item xs={4}>
             <FormControl fullWidth required>
               <TextField
                 fullWidth
-                type="number"
-                InputProps={{
-                  inputProps: {
-                    min: 1,
-                  },
-                }}
                 label={t('tokenIndex')}
                 placeholder="ex. 1"
+                value={tokenIndex}
                 onChange={handleTokenIndexChange}
               />
             </FormControl>

--- a/ui/src/components/Forms/BurnForm.tsx
+++ b/ui/src/components/Forms/BurnForm.tsx
@@ -38,7 +38,7 @@ export const BurnForm: React.FC = () => {
     setJsonPayload({
       pool: pool?.name,
       amount,
-      tokenIndex,
+      tokenIndex: tokenIndex?.toString(),
     });
   }, [pool, amount, tokenIndex, activeForm]);
 
@@ -100,7 +100,9 @@ export const BurnForm: React.FC = () => {
   };
 
   const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAmount(parseInt(event.target.value));
+    if (parseInt(event.target.value)) {
+      setAmount(parseInt(event.target.value));
+    }
   };
 
   return (

--- a/ui/src/components/Forms/BurnForm.tsx
+++ b/ui/src/components/Forms/BurnForm.tsx
@@ -28,7 +28,7 @@ export const BurnForm: React.FC = () => {
   const [tokenPools, setTokenPools] = useState<ITokenPool[]>([]);
   const [pool, setPool] = useState<ITokenPool>();
   const [amount, setAmount] = useState<number>(0);
-  const [tokenIndex, setTokenIndex] = useState<string | null>();
+  const [tokenIndex, setTokenIndex] = useState<number | null>();
   const [refresh, setRefresh] = useState<number>(0);
   const [tokenBalance, setTokenBalance] = useState<number>(0);
 
@@ -79,7 +79,7 @@ export const BurnForm: React.FC = () => {
   }, [pool, refresh]);
 
   useEffect(() => {
-    setTokenIndex(isFungible() ? null : '1');
+    setTokenIndex(isFungible() ? null : 1);
     if (!isFungible()) {
       setAmount(1);
     }
@@ -93,7 +93,10 @@ export const BurnForm: React.FC = () => {
   const handleTokenIndexChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setTokenIndex(event.target.value);
+    const index = parseInt(event.target.value);
+    if (index && index > 0) {
+      setTokenIndex(index);
+    }
   };
 
   const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -171,12 +174,17 @@ export const BurnForm: React.FC = () => {
             </FormControl>
           </Grid>
         </Grid>
-        {tokenIndex ? (
+        {tokenIndex && tokenIndex > -1 ? (
           <Grid item xs={4}>
             <FormControl fullWidth required>
               <TextField
                 fullWidth
                 type="number"
+                InputProps={{
+                  inputProps: {
+                    min: 1,
+                  },
+                }}
                 label={t('tokenIndex')}
                 placeholder="ex. 1"
                 onChange={handleTokenIndexChange}

--- a/ui/src/components/Forms/Contracts/DefineInterfaceForm.tsx
+++ b/ui/src/components/Forms/Contracts/DefineInterfaceForm.tsx
@@ -75,7 +75,9 @@ export const DefineInterfaceForm: React.FC = () => {
     if (activeForm !== TUTORIALS.DEFINE_CONTRACT_INTERFACE) {
       return;
     }
-    setPayloadMissingFields(!schema);
+    setPayloadMissingFields(
+      !schema || (interfaceFormat === 'abi' && (!name || !version))
+    );
     setJsonPayload({
       format: interfaceFormat,
       name,

--- a/ui/src/components/Forms/Contracts/RegisterContractApiForm.tsx
+++ b/ui/src/components/Forms/Contracts/RegisterContractApiForm.tsx
@@ -1,5 +1,6 @@
 import {
   FormControl,
+  FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
@@ -26,7 +27,9 @@ export const RegisterContractApiForm: React.FC = () => {
   const [contractInterfaces, setContractInterfaces] = useState<
     IContractInterface[]
   >([]);
-  const [contractInterfaceIdx, setContractInterfaceIdx] = useState<number>(0);
+  const [contractInterfaceIdx, setContractInterfaceIdx] = useState<
+    number | null
+  >();
   const [name, setName] = useState<string>('');
   const [contractAddress, setContractAddress] = useState<string>('');
 
@@ -37,8 +40,12 @@ export const RegisterContractApiForm: React.FC = () => {
     setPayloadMissingFields(!name || !contractAddress);
     setJsonPayload({
       name,
-      interfaceName: contractInterfaces[contractInterfaceIdx]?.name,
-      interfaceVersion: contractInterfaces[contractInterfaceIdx]?.version,
+      interfaceName: contractInterfaceIdx
+        ? contractInterfaces[contractInterfaceIdx]?.name
+        : '',
+      interfaceVersion: contractInterfaceIdx
+        ? contractInterfaces[contractInterfaceIdx]?.version
+        : '',
       address: contractAddress,
     });
   }, [name, contractInterfaceIdx, contractAddress, activeForm]);
@@ -69,7 +76,7 @@ export const RegisterContractApiForm: React.FC = () => {
               <InputLabel>{t('contractInterface')}</InputLabel>
               <Select
                 fullWidth
-                value={contractInterfaceIdx}
+                value={contractInterfaceIdx ?? ''}
                 label={t('contractInterface')}
                 onChange={(e) => {
                   setContractInterfaceIdx(e.target.value as number);
@@ -104,6 +111,9 @@ export const RegisterContractApiForm: React.FC = () => {
               label={t('address')}
               onChange={(e) => setContractAddress(e.target.value)}
             />
+            <FormHelperText id="address-helper-text">
+              {t('contractAddressHelperText')}
+            </FormHelperText>
           </FormControl>
         </Grid>
       </Grid>

--- a/ui/src/components/Forms/MintForm.tsx
+++ b/ui/src/components/Forms/MintForm.tsx
@@ -34,11 +34,12 @@ export const MintForm: React.FC = () => {
   );
 
   const [pool, setPool] = useState<ITokenPool>();
-  const [amount, setAmount] = useState<number>();
+  const [amount, setAmount] = useState<number>(1);
   const [refresh, setRefresh] = useState<number>(0);
 
   useEffect(() => {
     if (activeForm !== TUTORIALS.MINT) {
+      setAmount(1);
       return;
     }
     setPayloadMissingFields(!amount);
@@ -100,11 +101,9 @@ export const MintForm: React.FC = () => {
   }, [pool, refresh]);
 
   const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.length === 0) {
-      setAmount(undefined);
-      return;
+    if (parseInt(event.target.value)) {
+      setAmount(parseInt(event.target.value));
     }
-    setAmount(parseInt(event.target.value));
   };
 
   return (
@@ -167,6 +166,7 @@ export const MintForm: React.FC = () => {
               type="number"
               label={t('amount')}
               placeholder={t('exampleAmount')}
+              value={amount}
               onChange={handleAmountChange}
             />
           </FormControl>

--- a/ui/src/components/Forms/MintForm.tsx
+++ b/ui/src/components/Forms/MintForm.tsx
@@ -42,7 +42,7 @@ export const MintForm: React.FC = () => {
       setAmount(1);
       return;
     }
-    setPayloadMissingFields(!amount);
+    setPayloadMissingFields(!amount || !pool);
     if (!message) {
       setJsonPayload({
         pool: pool?.name,

--- a/ui/src/components/Forms/PoolForm.tsx
+++ b/ui/src/components/Forms/PoolForm.tsx
@@ -17,12 +17,14 @@ export const PoolForm: React.FC = () => {
   const { setJsonPayload, activeForm, setPayloadMissingFields } =
     useContext(ApplicationContext);
 
-  const [name, setName] = useState<string>();
-  const [symbol, setSymbol] = useState<string>();
+  const [name, setName] = useState<string>('');
+  const [symbol, setSymbol] = useState<string>('');
   const [type, setType] = useState<'fungible' | 'nonfungible'>('fungible');
 
   useEffect(() => {
     if (activeForm !== TUTORIALS.POOL) {
+      setName('');
+      setSymbol('');
       return;
     }
     setPayloadMissingFields(!name || !symbol ? true : false);
@@ -34,18 +36,10 @@ export const PoolForm: React.FC = () => {
   }, [name, symbol, type, activeForm]);
 
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.length === 0) {
-      setName(undefined);
-      return;
-    }
     setName(event.target.value);
   };
 
   const handleSymbolChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.length === 0) {
-      setSymbol(undefined);
-      return;
-    }
     setSymbol(event.target.value);
   };
 
@@ -60,6 +54,7 @@ export const PoolForm: React.FC = () => {
               fullWidth
               label={t('poolName')}
               placeholder={t('abcCoin')}
+              value={name}
               onChange={handleNameChange}
             />
           </Grid>
@@ -70,6 +65,7 @@ export const PoolForm: React.FC = () => {
               required
               label={t('poolSymbol')}
               placeholder={t('abc')}
+              value={symbol}
               onChange={handleSymbolChange}
             />
           </Grid>

--- a/ui/src/components/Forms/TransferForm.tsx
+++ b/ui/src/components/Forms/TransferForm.tsx
@@ -33,7 +33,7 @@ export const TransferForm: React.FC = () => {
   const [amount, setAmount] = useState<number>(1);
   const [tokenVerifiers, setTokenVerifiers] = useState<IVerifiers[]>([]);
   const [recipient, setRecipient] = useState<string>('');
-  const [tokenIndex, setTokenIndex] = useState<number | null>();
+  const [tokenIndex, setTokenIndex] = useState<string | null>('');
   const [tokenBalance, setTokenBalance] = useState<number>(0);
   const [refresh, setRefresh] = useState<number>(0);
 
@@ -42,7 +42,9 @@ export const TransferForm: React.FC = () => {
       setAmount(1);
       return;
     }
-    setPayloadMissingFields(!recipient || !amount);
+    setPayloadMissingFields(
+      !recipient || !amount || !pool || (!isFungible() && !tokenIndex)
+    );
     setJsonPayload({
       pool: pool?.name,
       amount,
@@ -81,7 +83,6 @@ export const TransferForm: React.FC = () => {
   }, [activeForm]);
 
   useEffect(() => {
-    setTokenIndex(isFungible() ? null : 1);
     if (!isFungible()) {
       setAmount(1);
     }
@@ -123,9 +124,7 @@ export const TransferForm: React.FC = () => {
   const handleTokenIndexChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    if (parseInt(event.target.value)) {
-      setTokenIndex(parseInt(event.target.value));
-    }
+    setTokenIndex(event.target.value);
   };
 
   const handleRecipientChange = (
@@ -227,19 +226,14 @@ export const TransferForm: React.FC = () => {
             />
           </FormControl>
         </Grid>
-        {tokenIndex && tokenIndex > -1 ? (
+        {!isFungible() ? (
           <Grid item xs={4}>
             <FormControl fullWidth required>
               <TextField
                 fullWidth
-                type="number"
+                value={tokenIndex}
                 label={t('tokenIndex')}
                 placeholder="ex. 1"
-                InputProps={{
-                  inputProps: {
-                    min: 1,
-                  },
-                }}
                 onChange={handleTokenIndexChange}
               />
             </FormControl>

--- a/ui/src/contexts/ApplicationContext.tsx
+++ b/ui/src/contexts/ApplicationContext.tsx
@@ -33,9 +33,6 @@ export interface IApplicationContext {
   // API Status
   apiStatus: IApiStatus | undefined;
   setApiStatus: Dispatch<SetStateAction<IApiStatus | undefined>>;
-  // Logs
-  logs: string[];
-  setLogs: Dispatch<SetStateAction<string[]>>;
 }
 
 export const ApplicationContext = createContext({} as IApplicationContext);

--- a/ui/src/contexts/EventContext.tsx
+++ b/ui/src/contexts/EventContext.tsx
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { createContext } from 'react';
+import { createContext, Dispatch, SetStateAction } from 'react';
 import { IEvent } from '../interfaces/api';
 import { IEventHistoryItem } from '../interfaces/events';
 
@@ -23,6 +23,8 @@ export interface IEventContext {
   logHistory: Map<string, IEventHistoryItem>;
   dumbAwaitedEventID: string | undefined;
   addAwaitedEventID: (apiRes: any) => void;
+  justSubmitted: boolean;
+  setJustSubmitted: Dispatch<SetStateAction<boolean>>;
 }
 
 export const EventContext = createContext({} as IEventContext);

--- a/ui/src/interfaces/api.ts
+++ b/ui/src/interfaces/api.ts
@@ -90,6 +90,7 @@ export interface IEvent {
   tx: string;
   batch?: IBatch;
   blockchainEvent?: IBlockchainEvent;
+  correlator?: string;
   contractAPI?: IFireflyApi;
   contractInterface?: IContractInterface;
   datatype?: IDatatype;

--- a/ui/src/interfaces/events.tsx
+++ b/ui/src/interfaces/events.tsx
@@ -8,4 +8,5 @@ export interface IEventHistoryItem {
   events: IEvent[];
   created: string;
   isComplete: boolean;
+  isFailed?: boolean;
 }

--- a/ui/src/pages/Home/views/MiddlePane.tsx
+++ b/ui/src/pages/Home/views/MiddlePane.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_PADDING,
   FFColors,
 } from '../../../theme';
+import { isSuccessfulResponse } from '../../../utils/strings';
 
 const getTutorials = (tutorialTitle: string) => {
   return TutorialSections.find((t) => t.title === tutorialTitle)?.tutorials.map(
@@ -98,15 +99,6 @@ export const MiddlePane = () => {
     const compiled = _.template(codeTemplate);
     const result = compiled(jsonPayload);
     setCodeBlock(result);
-  };
-
-  const isSuccessfulResponse = (statusCode: number) => {
-    if (statusCode >= 200 && statusCode < 299) {
-      return true;
-    } else if (statusCode >= 400 && statusCode < 600) {
-      return false;
-    }
-    return false;
   };
 
   const getApiStatusColor = () => {

--- a/ui/src/pages/Home/views/RightPane.tsx
+++ b/ui/src/pages/Home/views/RightPane.tsx
@@ -1,4 +1,8 @@
-import { CheckCircleOutline, ExpandMore } from '@mui/icons-material';
+import {
+  CheckCircleOutline,
+  ErrorOutline,
+  ExpandMore,
+} from '@mui/icons-material';
 import {
   Accordion,
   AccordionDetails,
@@ -79,8 +83,10 @@ export const RightPane: React.FC = () => {
                                       color="warning"
                                       size="20px"
                                     />
+                                  ) : !value.isFailed ? (
+                                    <CheckCircleOutline color={'success'} />
                                   ) : (
-                                    <CheckCircleOutline color="success" />
+                                    <ErrorOutline color={'error'} />
                                   )}
                                 </Grid>
                               </Grid>

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -24,6 +24,7 @@
   "connected": "Connected",
   "connectedToFirefly": "Listening for events from backend",
   "connector": "Connector",
+  "contractAddressHelperText": "The contract address on your blockchain",
   "contractApi": "Contract API",
   "contractApiConfirmed": "Contract API Confirmed",
   "contractInterface": "Contract Interface",

--- a/ui/src/utils/strings.ts
+++ b/ui/src/utils/strings.ts
@@ -17,3 +17,12 @@ export const isJsonString = (str: string) => {
   }
   return true;
 };
+
+export const isSuccessfulResponse = (statusCode: number) => {
+  if (statusCode >= 200 && statusCode < 299) {
+    return true;
+  } else if (statusCode >= 400 && statusCode < 600) {
+    return false;
+  }
+  return false;
+};


### PR DESCRIPTION
Restored token indices to string type. Failed transactions now show a different indicator, eliminated indefinite waiting when token transfer fails happen, better input validation. In cases where the waiting spinner spins indefinitely, switching forms will reset the Run button so that the user is not forced to refresh the page.

Previously, failed transactions show a purple check.
<img width="551" alt="image" src="https://user-images.githubusercontent.com/9773638/163633612-96dc498d-e040-46be-a099-a4c72d0f7be5.png">

 Now, it shows a red error. 
<img width="540" alt="image" src="https://user-images.githubusercontent.com/9773638/163633635-ee0a4593-6622-468d-89d0-7f10f77049c0.png">


Signed-off-by: Anastasia Lalamentik <anastasia.lalamentik@kaleido.io>
