### PR TITLE
changes to support FF version 1.0

### DIFF
--- a/server/test/common.test.ts
+++ b/server/test/common.test.ts
@@ -62,6 +62,7 @@ describe('Common Operations', () => {
 
     mockFireFly.getOrganizations.mockResolvedValueOnce(orgs);
     mockFireFly.getVerifiers.mockResolvedValueOnce(verifiers);
+    mockFireFly.getVerifiers.mockResolvedValueOnce([]);
 
     await request(server)
       .get('/api/common/verifiers')
@@ -70,5 +71,8 @@ describe('Common Operations', () => {
 
     expect(mockFireFly.getOrganizations).toHaveBeenCalledWith();
     expect(mockFireFly.getVerifiers).toHaveBeenCalledWith('default');
+
+    expect(mockFireFly.getOrganizations).toHaveBeenCalledWith();
+    expect(mockFireFly.getVerifiers).toHaveBeenCalledWith('ff_system');
   });
 });


### PR DESCRIPTION
 - query both `default` and `ff_system` namespaces for verifiers
 - assume multiparty mode if `multiparty` key is missing from status

closes #96 