### PR TITLE
update sandbox to work with different namespaces

### DIFF
--- a/server/src/clients/firefly.ts
+++ b/server/src/clients/firefly.ts
@@ -3,6 +3,7 @@ import { InternalServerError } from 'routing-controllers';
 
 export const firefly = new FireFly({
   host: process.env.FF_ENDPOINT || 'http://localhost:5000',
+  namespace: process.env.FF_DEFAULT_NAMESPACE || 'default',
 });
 
 firefly.onError((err) => {

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -388,4 +388,7 @@ export class DatatypeInterface {
 export class FFStatus {
   @IsBoolean()
   multiparty: boolean;
+
+  @IsString()
+  namespace: string;
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
     type: '',
     id: '',
   });
+  const [namespace, setNamespace] = useState('');
   const [tokensDisabled, setTokensDisabled] = useState(false);
   const [blockchainPlugin, setBlockchainPlugin] = useState('');
   const [tutorialSections, setTutorialSections] = useState<ITutorialSection[]>(
@@ -66,6 +67,7 @@ function App() {
         );
         const ffStatus = statusResponse as IFireflyStatus;
         setMultiparty(ffStatus.multiparty);
+        setNamespace(ffStatus.namespace);
         if (ffStatus.multiparty === true) {
           setTutorialSections(TutorialSections);
           fetchCatcher(SDK_PATHS.verifiers)
@@ -122,6 +124,7 @@ function App() {
             blockchainPlugin,
             multiparty,
             tutorialSections,
+            namespace,
           }}
         >
           <StyledEngineProvider injectFirst>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -39,6 +39,7 @@ import ReconnectingWebSocket from 'reconnecting-websocket';
 import { ReactComponent as DiscordLogo } from '../assets/Discord-Logo-White.svg';
 import { ResourceUrls } from '../constants/ResourceUrls';
 import { EventContext } from '../contexts/EventContext';
+import { ApplicationContext } from '../contexts/ApplicationContext';
 import { FF_EVENTS } from '../ff_models/eventTypes';
 import { DEFAULT_BORDER_RADIUS, DEFAULT_PADDING, FFColors } from '../theme';
 import { MenuLogo } from './Logos/MenuLogo';
@@ -52,6 +53,7 @@ export const Header: React.FC = () => {
   const { t } = useTranslation();
   const theme = useTheme();
   const { addLogToHistory } = useContext(EventContext);
+  const { namespace } = useContext(ApplicationContext);
   const [wsConnected, setWsConnected] = useState<boolean>(false);
   const webSocket = useRef<ReconnectingWebSocket | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -201,6 +203,11 @@ export const Header: React.FC = () => {
                   onClick={connectToWS}
                 />
               </Tooltip>
+              <Grid item paddingLeft={1}>
+                <Typography>
+                  {t('namespaceX', { namespace: namespace })}
+                </Typography>
+              </Grid>
               <IconButton
                 color="inherit"
                 onClick={() => setIsModalOpen(true)}

--- a/ui/src/contexts/ApplicationContext.tsx
+++ b/ui/src/contexts/ApplicationContext.tsx
@@ -36,6 +36,7 @@ export interface IApplicationContext {
   blockchainPlugin: string;
   multiparty: boolean;
   tutorialSections: ITutorialSection[];
+  namespace: string;
 }
 
 export const ApplicationContext = createContext({} as IApplicationContext);

--- a/ui/src/interfaces/api.ts
+++ b/ui/src/interfaces/api.ts
@@ -10,6 +10,7 @@ export interface IApiStatus {
 
 export interface IFireflyStatus {
   multiparty: boolean;
+  namespace: string;
 }
 
 export interface IBatch {

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -119,6 +119,7 @@
   "name": "Name",
   "namespaceConfirmed": "Namespace Confirmed",
   "namespaceID": "Namespace ID",
+  "namespaceX": "Namespace: {{namespace}}",
   "noAPIsRegisteredWithFireFly": "No APIs Registered with FireFly",
   "noBalancesForWallet": "No Balances for Wallet",
   "noConnectors": "No Token Connectors",


### PR DESCRIPTION
By setting the `FF_DEFAULT_NAMESPACE` environment variable when deploying the sandbox server, the sandbox will now work with namespaces other than `default`. 


Note: Further discussion is needed with @awrichar to figure out how sandbox + firefly-sdk can be updated to work with multiple namespaces. 




<img width="404" alt="Screen Shot 2022-09-02 at 1 15 59 PM" src="https://user-images.githubusercontent.com/10987380/188205175-942ae876-080b-488f-a75b-f66d6e151dda.png">


