### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,14 +2,21 @@
 
 The following is the list of current maintainers this repo:
 
+**Active maintainers**
+
 | Name              | GitHub          | Email                        | LFID              |
 | ----------------- | --------------- | ---------------------------- | ----------------- |
 | Alex Shorsher     | shorsher        | alex.shorsher@kaleido.io     | shorsher          |
-| Peter Broadhurst  | peterbroadhurst | peter.broadhurst@kaleido.io  | peterbroadhurst   |
 | Andrew Richardson | awrichar        | andrew.richardson@kaleido.io | Andrew.Richardson |
 | David Echelberger | eberger727      | david.echelberger@kaleido.io | dech727           |
 
 This list is to be kept up to date as maintainers are added or removed.
+
+**Emeritus maintainers**
+
+| Name              | GitHub          | Email                        | LFID              |
+| ----------------- | --------------- | ---------------------------- | ----------------- |
+| Peter Broadhurst  | peterbroadhurst | peter.broadhurst@kaleido.io  | peterbroadhurst   |
 
 # Expectations of Maintainers
 


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>