### PR TITLE
Add contract interface dropdown to token pool creation

### DIFF
--- a/server/src/controllers/tokens.ts
+++ b/server/src/controllers/tokens.ts
@@ -74,6 +74,9 @@ export class TokensController {
       name: body.name,
       symbol: body.symbol,
       type: body.type,
+      interface: {
+        id: body.contractInterface,
+      },
       config: {
         address: body.address,
         blockNumber: body.blockNumber,
@@ -285,7 +288,10 @@ export class TokensTemplateController {
     return formatTemplate(`
       const pool = await firefly.createTokenPool({
         name: <%= ${q('name')} %>,<% if (symbol) { %>
-        <% print('symbol: ' + ${q('symbol')} + ',') } %>
+        <% print('symbol: ' + ${q('symbol')} + ',') } %><% if (contractInterface) { %>
+        interface: {
+          id: <%= ${q('contractInterface')} %>
+        },<% } %>
         type: <%= ${q('type')} %>,
         config: {<% if (address) { %>
           <% print('address: ' + ${q('address')} + ',') } %>

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -148,6 +148,10 @@ export class TokenPoolInput {
 
   @IsString()
   @IsOptional()
+  contractInterface?: string;
+
+  @IsString()
+  @IsOptional()
   address?: string;
 
   @IsString()

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -174,6 +174,7 @@
   "tokenIndex": "Token Index",
   "tokenIndexes": "Token Indexes",
   "tokenPool": "Token Pool",
+  "tokenPoolContractInterfaceHelperText": "The FireFly Interface for a custom token contract. Use \"Automatic\" for built-in contracts.",
   "tokenPoolAddressHelperText": "The address of an existing token contract, if supported by the token connector.",
   "tokenPoolConfirmed": "Token Pool Confirmed",
   "tokenPoolFailed": "Token Pool Failed",


### PR DESCRIPTION
FireFly now supports specifying a contract interface for a custom contract when creating a token pool. This PR adds a dropdown to set that on the Sandbox UI. The code snippet and API requests have also been updated accordingly.

![Screen Shot 2023-01-16 at 1 57 39 PM](https://user-images.githubusercontent.com/2530008/212749433-3f32358f-aa4d-4f04-b873-116d6565fbf8.png)
![Screen Shot 2023-01-16 at 1 57 51 PM](https://user-images.githubusercontent.com/2530008/212749434-de51bd97-1846-481e-a394-f351bc370446.png)
