### PR TITLE
Fixing scroll direction for FFStateBox

### DIFF
--- a/ui/src/components/Boxes/ContractStateBox.tsx
+++ b/ui/src/components/Boxes/ContractStateBox.tsx
@@ -76,18 +76,14 @@ export const ContractStateBox: React.FC = () => {
               key={api.name}
             >
               {/* API Row */}
-              <Grid item xs={8} container pt={1}>
-                <HashPopover
-                  address={`${SDK_PATHS.contractsApiByName(api.name)}`}
-                  fullLength
-                  paper
-                />
+              <Grid item xs={10} container pt={1}>
+                <HashPopover address={`${api.name}`} fullLength paper />
               </Grid>
               <Grid
                 container
                 justifyContent="flex-end"
                 item
-                xs={4}
+                xs={2}
                 alignItems="center"
               >
                 <DownloadButton filename={api.name} url={api.urls.openapi} />

--- a/ui/src/components/Boxes/FFStateBox.tsx
+++ b/ui/src/components/Boxes/FFStateBox.tsx
@@ -18,8 +18,6 @@ export const FFStateBox: React.FC<Props> = ({ header, children }) => {
       sx={{
         border: `3px solid ${theme.palette.background.paper}`,
         borderRadius: DEFAULT_BORDER_RADIUS,
-        maxHeight: '250px',
-        overflow: 'auto',
       }}
     >
       {/* Header */}
@@ -28,7 +26,19 @@ export const FFStateBox: React.FC<Props> = ({ header, children }) => {
           {header}
         </Typography>
       </Grid>
-      {children}
+      <Grid
+        container
+        direction="column"
+        width="100%"
+        p={1}
+        sx={{
+          maxHeight: '222px',
+          overflow: 'auto',
+          flexWrap: 'nowrap',
+        }}
+      >
+        {children}
+      </Grid>
     </Grid>
   );
 };

--- a/ui/src/translations/en.json
+++ b/ui/src/translations/en.json
@@ -7,7 +7,7 @@
   "apiID": "API ID",
   "apiResponse": "API Response",
   "apis": "APIs",
-  "apisKnownToFirefly": "APIs Known to FireFly",
+  "apisKnownToFirefly": "APIs known to current FireFly namespace",
   "appCodeInstructions": "Build an action using the panels on the left. Click \"Run\" to execute the action via the backend server. FireFly events related to the transaction will appear on the right.",
   "applicationCode": "Application Code",
   "approvalID": "Approval ID",


### PR DESCRIPTION
Fixes https://github.com/hyperledger/firefly-sandbox/issues/113

- Fixed the scroll direction for FFStateBox to be vertical
- Fixed the position of the header in FFStateBox so that it doesn't move when scrolling
- On the Contract tab:
  - removed the API path prefix as that's the internal path for the sandbox UI server which is not helpful.
  - expanded the API name hashpopover to be wider
  - updated the title of the API list box to indicate only the APIs in the current namespace are listed

Signed-off-by: Chengxuan Xing <chengxuan.xing@kaleido.io>

# Contract tab:
![image](https://user-images.githubusercontent.com/5425125/213395091-d54a46d1-1c6c-4320-9135-8d93ee5c9524.png)

# Token tab:
![image](https://user-images.githubusercontent.com/5425125/213395143-c2952eab-69db-4635-883a-8179c0aa39b7.png)
